### PR TITLE
twitter names on mobile are not clickable anymore

### DIFF
--- a/src/common/pageManagers/twitterPageManager.js
+++ b/src/common/pageManagers/twitterPageManager.js
@@ -11,7 +11,6 @@ export class TwitterPageManager extends AbstractPageManager {
     constructor(document) {
         super(document)
         this.mobile = deviceType() == 'mobile'
-        console.log("this.mobile", this.mobile)
     }
 
     async init() {
@@ -215,14 +214,26 @@ export class TwitterPageManager extends AbstractPageManager {
       let dropdown = dropdownContent;
       dropdown.addEventListener("click", (e) => e.stopPropagation());
         this.document.body.append(dropdown);
+
         let rect = icon.getBoundingClientRect();
         dropdown.classList.add("idrissTwitterDropdown");
         dropdown.style.all = "initial";
         dropdown.style.position = "absolute";
-        dropdown.style.left = scrollX + rect.left + "px";
-        dropdown.style.top = scrollY + rect.top + rect.height + "px";
+
+        let dropdownLeft = scrollX + rect.left;
+        let dropdownTop = scrollY + rect.top + rect.height;
+
+        dropdown.style.left = `${dropdownLeft}px`;
+        dropdown.style.top = `${dropdownTop}px`;
         dropdown.style.zindex = 1000000;
         dropdown.onclick = () => dropdown.classList.add("isClicked");
+
+        let viewportWidth = window.innerWidth;
+        let dropdownRightEdge = dropdownLeft + dropdown.offsetWidth;
+
+        if (this.mobile && dropdownRightEdge > viewportWidth) {
+            dropdown.style.left = Math.max(viewportWidth - dropdown.offsetWidth, 0) + "px";
+        }
   
         if (dropdown !== this.lastDropdown) {
           this.lastDropdown?.remove();

--- a/src/common/pageManagers/twitterPageManager.js
+++ b/src/common/pageManagers/twitterPageManager.js
@@ -192,8 +192,8 @@ export class TwitterPageManager extends AbstractPageManager {
       let linkElem = parent.querySelector(`a[href="/${name.replace('@', '')}"]`);
       if (this.mobile){
         linkElem?.addEventListener('click', function(event) {
-            event.preventDefault();  // Prevents the default link action
-            event.stopPropagation(); // Stops the event from propagating to other handlers
+            event.preventDefault(); 
+            event.stopPropagation();
         }, true);
       }
       let _iconUrl = data[name] ? this.allIcons[data[name].iconUrl] : this.allIcons.default;

--- a/src/common/pageManagers/twitterPageManager.js
+++ b/src/common/pageManagers/twitterPageManager.js
@@ -209,10 +209,10 @@ export class TwitterPageManager extends AbstractPageManager {
       appendingElem?.append(icon);
     //   if (await this.checkSBT(Object.values(data)[0])) appendingElem?.append(sbtIcon);
       icon.onmouseover = (e) => {
-      e.stopPropagation();
-      e.preventDefault();
-      let dropdown = dropdownContent;
-      dropdown.addEventListener("click", (e) => e.stopPropagation());
+        e.stopPropagation();
+        e.preventDefault();
+        let dropdown = dropdownContent;
+        dropdown.addEventListener("click", (e) => e.stopPropagation());
         this.document.body.append(dropdown);
 
         let rect = icon.getBoundingClientRect();

--- a/src/common/pageManagers/twitterPageManager.js
+++ b/src/common/pageManagers/twitterPageManager.js
@@ -3,14 +3,16 @@ import {RequestLimiter} from "../RequestLimiter";
 import {Tipping} from "../tipping/Tipping";
 import {TippingUnregistered} from '../tipping/tippingUnregistered'
 import {CustomWidget} from "../tipping/customTwitter";
-import {getCustomTwitter} from "../utils";
+import {getCustomTwitter, deviceType} from "../utils";
 
 export class TwitterPageManager extends AbstractPageManager {
     static namesResults = {};
 
     constructor(document) {
         super(document)
-            }
+        this.mobile = deviceType() == 'mobile'
+        console.log("this.mobile", this.mobile)
+    }
 
     async init() {
         this.requestLimiter = new RequestLimiter([{amount: 10, time: 1000}]);
@@ -187,6 +189,13 @@ export class TwitterPageManager extends AbstractPageManager {
 
     createIcon = async (parent, data, dropdownContent, name) => {
     //   const sbtIcon = this.createIconStyling(this.sbtIconUrl, "sbtIcon", "MJ-SBT", {borderLeft: "", width: "1.2em", height: "1.2em", margin: "-1px 0 -1px -2px"});
+      let linkElem = parent.querySelector(`a[href="/${name.replace('@', '')}"]`);
+      if (this.mobile){
+        linkElem?.addEventListener('click', function(event) {
+            event.preventDefault();  // Prevents the default link action
+            event.stopPropagation(); // Stops the event from propagating to other handlers
+        }, true);
+      }
       let _iconUrl = data[name] ? this.allIcons[data[name].iconUrl] : this.allIcons.default;
       let iconClassName = "idrissIcon"
       const icon = this.createIconStyling(_iconUrl, iconClassName, name);

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -114,6 +114,17 @@ export function getCustomTwitter() {
   return freshCustomTwitter;
 }
 
+export function deviceType() {
+    const ua = navigator.userAgent;
+    if (/(tablet|ipad|playbook|silk)|(android(?!.*mobi))/i.test(ua)) {
+        return "tablet";
+    }
+    if (/Mobile|iP(hone|od)|Android|BlackBerry|IEMobile|Kindle|Silk-Accelerated|(hpw|web)OS|Opera M(obi|ini)/.test(ua)) {
+        return "mobile";
+    }
+    return "desktop";
+}
+
 fetchCustomTwitter();
 // Automatic fetching every 5 minutes
 const fetchInterval = 5 * 60 * 1000; // 5 minutes in milliseconds


### PR DESCRIPTION
As the IDriss icon is appended to the name element on Twitter, clicking it will open the profile of a user. On mobile, hovering the mouse like on pc is not possible. Hence, sending transactions is only possible when visiting someone's profile (and not from the context of a tweet). This PR fixes this issue by making the name link non-clickable on mobile screens. The profile can still be visited by clicking on the profile picture.