### PR TITLE
Restore proposals query placeholder data prop

### DIFF
--- a/src/application/agora/hooks/use-proposals-query.ts
+++ b/src/application/agora/hooks/use-proposals-query.ts
@@ -14,5 +14,8 @@ export const useProposalsQuery = ({ offset, enabled = true }: Properties) => {
     }),
     staleTime: Number.POSITIVE_INFINITY,
     enabled,
+    placeholderData: (previousData) => {
+      return previousData;
+    },
   });
 };

--- a/src/application/agora/widgets/proposal-main.container.tsx
+++ b/src/application/agora/widgets/proposal-main.container.tsx
@@ -18,13 +18,15 @@ const Base = ({ className, onClose }: Properties) => {
   const proposalQuery = useProposalsQuery({ offset: currentProposalIndex });
   const currentProposal = proposalQuery.data?.proposal;
 
+  const isLoadingProposal =
+    proposalQuery.isLoading || proposalQuery.isPlaceholderData;
   const isPreviousProposalAvailable = currentProposalIndex > 0;
   const isNextProposalAvailable = Boolean(
     proposalQuery.data?.metadata.has_next,
   );
 
   const showPreviousProposal = () => {
-    if (!isPreviousProposalAvailable || proposalQuery.isLoading) {
+    if (!isPreviousProposalAvailable || isLoadingProposal) {
       return;
     }
 
@@ -34,7 +36,7 @@ const Base = ({ className, onClose }: Properties) => {
   };
 
   const showNextProposal = () => {
-    if (!isNextProposalAvailable || proposalQuery.isLoading) {
+    if (!isNextProposalAvailable || isLoadingProposal) {
       return;
     }
 
@@ -57,7 +59,7 @@ const Base = ({ className, onClose }: Properties) => {
   return (
     <Proposal
       pagination={pagination}
-      isLoading={proposalQuery.isLoading}
+      isLoading={isLoadingProposal}
       data={currentProposal}
       className={className}
       onClose={onClose}

--- a/src/application/snapshot/hooks/use-proposals-query.ts
+++ b/src/application/snapshot/hooks/use-proposals-query.ts
@@ -20,5 +20,8 @@ export const useProposalsQuery = ({
     }),
     staleTime: Number.POSITIVE_INFINITY,
     enabled,
+    placeholderData: (previousData) => {
+      return previousData;
+    },
   });
 };

--- a/src/application/snapshot/widgets/organization-proposals.container.tsx
+++ b/src/application/snapshot/widgets/organization-proposals.container.tsx
@@ -22,9 +22,11 @@ const Base = ({ className, officialName, onClose }: Properties) => {
   });
   const currentProposal = proposalQuery.data?.proposal;
 
+  const isLoadingProposal =
+    proposalQuery.isLoading || proposalQuery.isPlaceholderData;
   const isPreviousProposalAvailable = currentProposalIndex > 0;
   const isNextProposalAvailable =
-    Boolean(proposalQuery.data?.hasNextProposal) && !proposalQuery.isLoading;
+    Boolean(proposalQuery.data?.hasNextProposal) && !isLoadingProposal;
 
   const showPreviousProposal = () => {
     if (!isPreviousProposalAvailable) {
@@ -60,7 +62,7 @@ const Base = ({ className, officialName, onClose }: Properties) => {
   return (
     <Proposal
       pagination={pagination}
-      isLoading={proposalQuery.isLoading}
+      isLoading={isLoadingProposal}
       data={currentProposal}
       className={className}
       onClose={onClose}

--- a/src/application/tally/hooks/use-proposals-query.ts
+++ b/src/application/tally/hooks/use-proposals-query.ts
@@ -22,5 +22,8 @@ export const useProposalsQuery = ({
     retryDelay: 1800,
     staleTime: Number.POSITIVE_INFINITY,
     enabled,
+    placeholderData: (previousData) => {
+      return previousData;
+    },
   });
 };

--- a/src/application/tally/widgets/organization-proposals.container.tsx
+++ b/src/application/tally/widgets/organization-proposals.container.tsx
@@ -32,15 +32,17 @@ const Base = ({ className, onClose, username }: Properties) => {
   const currentProposal = proposalQuery.data?.nodes[0];
   const nextProposal = proposalQuery.data?.nodes[1];
 
+  const isLoadingProposal =
+    proposalQuery.isLoading || proposalQuery.isPlaceholderData;
   const isPreviousProposalAvailable = previousProposalCursors.length > 0;
   const isNextProposalAvailable =
-    nextProposal !== undefined && !proposalQuery.isLoading;
+    nextProposal !== undefined && !isLoadingProposal;
 
   const showPreviousProposal = () => {
     const previousProposalCursor = previousProposalCursors.at(-1);
     if (
       !isPreviousProposalAvailable ||
-      proposalQuery.isLoading ||
+      isLoadingProposal ||
       previousProposalCursor === undefined
     ) {
       return;
@@ -65,7 +67,7 @@ const Base = ({ className, onClose, username }: Properties) => {
   };
 
   useEffect(() => {
-    if (proposalQuery.isLoading) {
+    if (isLoadingProposal) {
       return;
     }
 
@@ -73,7 +75,7 @@ const Base = ({ className, onClose, username }: Properties) => {
     if (newFetchedProposalInfo) {
       setNextProposalCursor(newFetchedProposalInfo.pageInfo.firstCursor);
     }
-  }, [proposalQuery]);
+  }, [isLoadingProposal, proposalQuery]);
 
   const pagination: Pagination = {
     hasPrevious: isPreviousProposalAvailable,
@@ -88,7 +90,7 @@ const Base = ({ className, onClose, username }: Properties) => {
   return (
     <Proposal
       pagination={pagination}
-      isLoading={proposalQuery.isLoading}
+      isLoading={isLoadingProposal}
       proposalDetails={currentProposal}
       className={className}
       onClose={onClose}

--- a/src/final/hooks/use-prefetch-proposals.ts
+++ b/src/final/hooks/use-prefetch-proposals.ts
@@ -38,10 +38,20 @@ export const usePrefetchProposals = ({ widgetData }: Properties) => {
       applicationsStatus.tally && widgetData.proposalsSources.includes('tally'),
   });
 
-  const isPrefetched =
-    !agoraProposalsQuery.isLoading &&
+  const isAgoraProposalPrefetched =
+    !agoraProposalsQuery.isLoading && !agoraProposalsQuery.isPlaceholderData;
+
+  const isSnapshotProposalPrefetched =
     !snapshotProposalsQuery.isLoading &&
-    !tallyProposalsQuery.isLoading;
+    !snapshotProposalsQuery.isPlaceholderData;
+
+  const isTallyProposalPrefetched =
+    !tallyProposalsQuery.isLoading && !tallyProposalsQuery.isPlaceholderData;
+
+  const isPrefetched =
+    isAgoraProposalPrefetched &&
+    isSnapshotProposalPrefetched &&
+    isTallyProposalPrefetched;
 
   const hasAgoraProposal = Boolean(agoraProposalsQuery.data?.proposal);
   const hasSnapshotProposal = Boolean(snapshotProposalsQuery.data?.proposal);

--- a/src/final/widgets/proposals/organisation-proposals.tsx
+++ b/src/final/widgets/proposals/organisation-proposals.tsx
@@ -119,7 +119,7 @@ const Base = ({ widgetData, onClose, className }: Properties) => {
       value={activeTab}
       onValueChange={changeTab}
     >
-      <Tabs.List className="flex shrink-0">
+      <Tabs.List className="relative top-[2px] flex shrink-0 items-end">
         {userActiveProposalSources.map((source) => {
           const isActive = source === activeTab;
           const imageSource = PROPOSAL_SOURCE_TO_IMG[source];
@@ -129,10 +129,10 @@ const Base = ({ widgetData, onClose, className }: Properties) => {
           return (
             <Tabs.Trigger
               className={classes(
-                'relative flex h-[25px] w-[100px] items-center space-x-1.5 rounded-t-lg px-2 pt-1 text-xs font-bold',
-                'transition-all duration-75 ease-linear will-change-transform',
+                'relative flex h-[26px] w-[100px] items-center space-x-1.5 rounded-t-lg px-2 pt-1 text-xs font-bold',
+                'transition-all duration-[85] ease-linear will-change-[transform,top]',
                 !isActive &&
-                  'top-[1px] -translate-x-[3px] scale-95 brightness-75',
+                  'top-[2px] -translate-x-[2px] scale-95 pb-[1px] brightness-[0.85]',
                 sourceClassnames.trigger,
               )}
               key={source}

--- a/src/final/widgets/proposals/organisation-proposals.tsx
+++ b/src/final/widgets/proposals/organisation-proposals.tsx
@@ -50,7 +50,13 @@ const Base = ({ widgetData, onClose, className }: Properties) => {
     widgetData,
   });
 
-  const firstSource = activeSources[0];
+  const userActiveProposalSources = widgetData.proposalsSources.filter(
+    (source) => {
+      return activeSources.includes(source);
+    },
+  );
+
+  const firstSource = userActiveProposalSources[0];
 
   const [activeTab, setActiveTab] = useState<ProposalSource>();
 
@@ -114,7 +120,7 @@ const Base = ({ widgetData, onClose, className }: Properties) => {
       onValueChange={changeTab}
     >
       <Tabs.List className="flex shrink-0">
-        {widgetData.proposalsSources.map((source) => {
+        {userActiveProposalSources.map((source) => {
           const isActive = source === activeTab;
           const imageSource = PROPOSAL_SOURCE_TO_IMG[source];
           const sourceClassnames = PROPOSAL_SOURCE_TO_CLASSES[source];
@@ -138,7 +144,7 @@ const Base = ({ widgetData, onClose, className }: Properties) => {
           );
         })}
       </Tabs.List>
-      {widgetData.proposalsSources.map((source) => {
+      {userActiveProposalSources.map((source) => {
         return (
           <Tabs.Content key={source} value={source}>
             <Component source={source} className="rounded-r-lg rounded-bl-lg" />


### PR DESCRIPTION
- Restored isPlaceholderData prop to prevent proposal widgets from disappearing when loading the next proposal.

- Updated the active proposals source for the proposal widgets layer. The previous configuration contained a bug where the Agora widget would appear for users without any widget (as the first available) due to prefetching.

- Lowered inactive tab 


https://github.com/user-attachments/assets/35ac43ae-95ad-4981-a1ad-5cff5504c55e

