### PR TITLE
fix: remove wallet when wallet changed or deauthorized website

### DIFF
--- a/apps/extension/src/application/trading-copilot/hooks/use-login-via-siwe.ts
+++ b/apps/extension/src/application/trading-copilot/hooks/use-login-via-siwe.ts
@@ -44,13 +44,15 @@ export const useLoginViaSiwe = () => {
         wallet.account,
       );
 
-      if (!loggedInToCurrentWallet && accounts[0]) {
+      if (loggedInToCurrentWallet && accounts[0]) {
         setWalletInfo({
           account: getAddress(accounts[0]),
           provider,
           chainId: hexToNumber(chainId),
           providerRdns: providerRdns,
         });
+      } else {
+        return;
       }
 
       const walletClient = createWalletClient(wallet);

--- a/packages/wallet-connect/src/context.tsx
+++ b/packages/wallet-connect/src/context.tsx
@@ -148,11 +148,15 @@ export const WalletContextProvider = (properties: {
 
   useEffect(() => {
     wallet?.provider.on('accountsChanged', (accounts) => {
-      const loggedInToCurrentWallet = getAddress(accounts[0] ?? '0x').includes(
-        wallet.account,
-      );
+      if (accounts[0]) {
+        const loggedInToCurrentWallet = getAddress(accounts[0]).includes(
+          wallet.account,
+        );
 
-      if (!loggedInToCurrentWallet) {
+        if (!loggedInToCurrentWallet) {
+          removeWalletInfo();
+        }
+      } else {
         removeWalletInfo();
       }
     });


### PR DESCRIPTION
Updated provider accountsChanged listener to remove wallet when user changed wallet or deauthorized website, to prevent error in console with missing wallet address.