### PR TITLE
Feat: unsaved changes toast (QA 38)

### DIFF
--- a/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
@@ -297,7 +297,9 @@ export default function StreamAlerts() {
         setShowRefreshAlert(true);
       }, 3000);
 
-      return () => clearTimeout(timer);
+      return () => {
+        return clearTimeout(timer);
+      };
     }
     return;
   }, [saveSuccess]);


### PR DESCRIPTION
## Overview
Solves QA # 38: toast behavior in Alerts: on any change show Unsaved changes toast (persistent until saved) --> after saving show Settings saved --> after disappears show Refresh the browser source... (both appear for same duration as now)