### PR TITLE
fix: Icon for "My Stats & History"

### DIFF
--- a/apps/main-landing/src/app/creators/[name]/donate-page-avatar-menu.tsx
+++ b/apps/main-landing/src/app/creators/[name]/donate-page-avatar-menu.tsx
@@ -62,7 +62,7 @@ export function DonatePageAvatarMenu() {
                   className="group flex min-h-[32px] cursor-pointer items-center gap-3 rounded-[4px] px-3 py-1"
                 >
                   <Icon
-                    name="BadgeDollarSign"
+                    name="LineChart"
                     size={20}
                     className="text-neutral-600 group-hover:text-mint-600"
                   />


### PR DESCRIPTION
## Overview
Icon was taken from Earnings on creators app sidebar. FIxed to show LineChart from tab pill inside Earnings page.