### PR TITLE
feat: Toast "require portrait mode" on test alert button (N31)

### DIFF
--- a/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
+++ b/apps/main-landing/src/app/creators/app/setup/stream-alerts/page.tsx
@@ -6,7 +6,7 @@ import { Card } from '@idriss-xyz/ui/card';
 import { Form } from '@idriss-xyz/ui/form';
 import { Toggle } from '@idriss-xyz/ui/toggle';
 import { getAccessToken } from '@privy-io/react-auth';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { isAddress } from 'viem';
 import { GradientBorder } from '@idriss-xyz/ui/gradient-border';
@@ -125,6 +125,7 @@ export default function StreamAlerts() {
   const [confirmButtonText, setConfirmButtonText] = useState('Copy link');
   const [wasCopied, setWasCopied] = useState(false);
   const [unsavedChangesToastId, setUnsavedChangesToastId] = useState('');
+  const hasShownTestAlertToastReference = useRef(false);
 
   const alertSounds = [
     ...defaultAlertSounds,
@@ -492,6 +493,24 @@ export default function StreamAlerts() {
                               TEST ALERT
                             </Button>
                           );
+                        }}
+                        onChange={(opened) => {
+                          if (
+                            opened &&
+                            !hasShownTestAlertToastReference.current
+                          ) {
+                            hasShownTestAlertToastReference.current = true;
+                            toast({
+                              type: 'error',
+                              heading:
+                                'Collectible alerts require portrait mode',
+                              description:
+                                'Test both tokens and collectibles to confirm they display correctly',
+                              iconName: 'BellRing',
+                              autoClose: true,
+                              duration: 6000,
+                            });
+                          }
                         }}
                       >
                         {() => {

--- a/apps/main-landing/src/app/creators/context/toast-context.tsx
+++ b/apps/main-landing/src/app/creators/context/toast-context.tsx
@@ -20,6 +20,7 @@ export interface ToastData {
   autoClose?: boolean;
   closable?: boolean;
   actionButtons?: (close: () => void) => ReactNode;
+  duration?: number;
 }
 
 interface ToastContextValue {
@@ -80,6 +81,8 @@ export const ToastProvider = ({ children }: ToastProviderProperties) => {
               description={toastData.description}
               iconName={toastData.iconName}
               autoClose={toastData.autoClose}
+              closable={toastData.closable}
+              duration={toastData.duration}
               actionButtons={toastData.actionButtons}
               onClose={() => {
                 return removeToast(toastData.id);

--- a/packages/ui/src/components/dropdown/dropdown.tsx
+++ b/packages/ui/src/components/dropdown/dropdown.tsx
@@ -11,6 +11,7 @@ type Properties = {
   children: (properties: ChildrenRenderProperties) => ReactNode;
   className?: string;
   contentAlign?: 'start' | 'center' | 'end';
+  onChange?: (opened: boolean) => void;
 };
 
 const DropdownBase = ({
@@ -18,12 +19,17 @@ const DropdownBase = ({
   children,
   className,
   contentAlign,
+  onChange,
 }: Properties) => {
   const [isOpened, setIsOpened] = useState(false);
 
-  const onOpenChange = useCallback((opened: boolean) => {
-    setIsOpened(opened);
-  }, []);
+  const onOpenChange = useCallback(
+    (opened: boolean) => {
+      setIsOpened(opened);
+      onChange?.(opened);
+    },
+    [onChange],
+  );
 
   const close = useCallback(() => {
     onOpenChange(false);

--- a/packages/ui/src/components/toast/toast.tsx
+++ b/packages/ui/src/components/toast/toast.tsx
@@ -18,6 +18,7 @@ type Properties = {
   heading: string;
   description?: string;
   autoClose?: boolean;
+  duration?: number;
   closable?: boolean;
   show?: boolean;
   iconName?: IconName;
@@ -36,6 +37,7 @@ export const Toast = forwardRef(
       heading,
       description,
       autoClose,
+      duration,
       closable,
       iconName,
       onClose,
@@ -60,13 +62,13 @@ export const Toast = forwardRef(
       if (autoClose && isVisible) {
         const timeout = setTimeout(() => {
           handleClose();
-        }, 3000);
+        }, duration ?? 3000);
         return () => {
           return clearTimeout(timeout);
         };
       }
       return () => {};
-    }, [isVisible, autoClose, onClose, handleClose]);
+    }, [isVisible, autoClose, duration, onClose, handleClose]);
 
     if (!isVisible) return null;
 


### PR DESCRIPTION
## Overview
Added this:
<img width="616" height="331" alt="image" src="https://github.com/user-attachments/assets/758343e6-b75a-44a0-8752-967561853005" />

Added optional "duration" property to toast logic and increased to 6s for this toast.
Added onChange to Dropdown component to trigger the toast outside of the rendering phase (used to trigger compile errors).