### PR TITLE
Fix: Hide privy popup

### DIFF
--- a/packages/constants/src/constants.ts
+++ b/packages/constants/src/constants.ts
@@ -564,7 +564,7 @@ export const DEFAULT_ALLOWED_CHAINS_IDS = [
 export const EMPTY_HEX = '0x';
 
 export const COPILOT_API_URL = 'https://copilot-api.idriss.xyz';
-export const CREATOR_API_URL = 'http://localhost:4000';
+export const CREATOR_API_URL = 'https://core-staging-4c69.up.railway.app';
 
 export const DEFAULT_DONATION_MIN_ALERT_AMOUNT = 1;
 export const DEFAULT_DONATION_MIN_TTS_AMOUNT = 3;


### PR DESCRIPTION
Second try at fixing this, now with the classed found below
<img width="1588" height="807" alt="Captura desde 2025-10-08 07-15-43" src="https://github.com/user-attachments/assets/6995f816-3461-4bae-aa29-48dd1cfd0bb9" />
